### PR TITLE
Add missing requests package

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -6,3 +6,4 @@ Shapely>=1.5.7
 transifex-client==0.11.1b0
 Babel>=1.3
 Flask
+requests


### PR DESCRIPTION
When you try `./geozones.py`, you get below error in a virtual environment

```
Traceback (most recent call last):
  File "./geozones.py", line 18, in <module>
    import france  # noqa
  File "/home/thomas/git/geozones/france.py", line 7, in <module>
    from dbpedia import DBPedia
  File "/home/thomas/git/geozones/dbpedia.py", line 1, in <module>
    import requests
ImportError: No module named 'requests'
```
I've confirmed the dependency to `requests` at https://github.com/etalab/geozones/blob/master/dbpedia.py.
I choose to solve the dependencies by adding the lib in current edited file instead of trying to solve it switching to the standard `urllib` module.