### PR TITLE
Explicitely specify serialized properties

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,9 @@ The following properties are exported in the GeoJSON output:
 :parents:
     A list of every known parent zone identifier
 
+Note that you can choose via the `keys` option which properties you would like
+to export during the `dist`ribution step.
+
 
 Translations
 ------------
@@ -179,7 +182,7 @@ Perform some non geospatial processing (ex: set the postal codes, attach the par
 ``dist``
 ~~~~~~~~
 
-Dump the produced dataset as GeoJSON files for distribution.
+Dump the produced dataset as GeoJSON or MSGPack files for distribution.
 Files are dumped in a build subdirectory.
 
 
@@ -225,6 +228,19 @@ You can export data in (Geo)JSON or `msgpack <http://msgpack.org/>`_ formats.
 The msgpack format consumes more CPU on deserialization but does not take
 many gigabytes of RAM given that it can iterate over data without loading
 the whole file.
+
+
+``keys``
+~~~~~~~~
+
+You can export only the properties that you want to use.
+This option only works with the JSON serialization.
+
+.. code-block:: shell
+
+    # Only export population and area without geometry
+    $ ./geozones.py dist -k population,area
+
 
 
 Reused datasets

--- a/geozones.py
+++ b/geozones.py
@@ -147,10 +147,12 @@ def postprocess(ctx, only):
 @click.option('-c/-nc', '--compress/--no-compress', default=True)
 @click.option('-r', '--serialization', default='json',
               type=click.Choice(['json', 'msgpack']))
-def dist(ctx, pretty, split, compress, serialization):
+@click.option('-k', '--keys', default=None)
+def dist(ctx, pretty, split, compress, serialization, keys):
     '''Dump a distributable file'''
-    title('Dumping data to {serialization}'.format(
-        serialization=serialization))
+    keys = keys and keys.split(',')
+    title('Dumping data to {serialization} with keys {keys}'.format(
+        serialization=serialization, keys=keys))
     geozones = DB()
     filenames = []
 
@@ -168,7 +170,7 @@ def dist(ctx, pretty, split, compress, serialization):
                 zones = geozones.find({'level': level_id})
                 if serialization == 'json':
                     with open(filename, 'w') as out:
-                        geojson.dump(zones, out, pretty=pretty)
+                        geojson.dump(zones, out, pretty=pretty, keys=keys)
                 else:
                     packer = msgpack.Packer(use_bin_type=True)
                     with open(filename, 'wb') as out:
@@ -181,7 +183,7 @@ def dist(ctx, pretty, split, compress, serialization):
             zones = geozones.find({'level': {'$in': level_ids}})
             if serialization == 'json':
                 with open(filename, 'w') as out:
-                    geojson.dump(zones, out, pretty=pretty)
+                    geojson.dump(zones, out, pretty=pretty, keys=keys)
             else:
                 packer = msgpack.Packer(use_bin_type=True)
                 with open(filename, 'wb') as out:
@@ -237,7 +239,8 @@ def dist(ctx, pretty, split, compress, serialization):
 @click.option('-c/-nc', '--compress/--no-compress', default=False)
 @click.option('-r', '--serialization', default='json',
               type=click.Choice(['json', 'msgpack']))
-def full(ctx, drop, pretty, split, compress, serialization):
+@click.option('-k', '--keys', default=None)
+def full(ctx, drop, pretty, split, compress, serialization, keys):
     '''
     Perfom a full processing
 
@@ -248,7 +251,7 @@ def full(ctx, drop, pretty, split, compress, serialization):
     ctx.invoke(aggregate)
     ctx.invoke(postprocess)
     ctx.invoke(dist, pretty=pretty, split=split, compress=compress,
-               serialization=serialization)
+               serialization=serialization, keys=keys)
 
 
 @cli.command()


### PR DESCRIPTION
Introducing the `keys` options to reduce the generated file to chosen properties and have the ability not to export geometries.