### PR TITLE
Added administrative level field to levels

### DIFF
--- a/.remarkrc
+++ b/.remarkrc
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "remark-preset-lint-recommended",
+    ["remark-lint-list-item-indent", "space"]
+  ]
+}

--- a/LISEZMOI.md
+++ b/LISEZMOI.md
@@ -9,17 +9,12 @@ Ils utilisent les [GeoIDs](https://github.com/etalab/geoids).
 
 Les sources de données sont :
 
-* [les exports OpenStreetMap](http://osm13.openstreetmap.fr/~cquest/openfla/export/)
-  pour les arrondissements, EPCI, départements, régions, communes et cantons
-* [les contours des IRIS issus de l’INSEE](https://www.data.gouv.fr/fr/datasets/contour-des-iris-insee-tout-en-un/)
-* [les contours des pays de TheMaticMapping](http://thematicmapping.org/downloads/)
-  pour l’outre-mer
-* [la base officielle des code postaux de La Poste](https://www.data.gouv.fr/fr/datasets/base-officielle-des-codes-postaux/)
-  pour les codes postaux
-* [la liste des EPCI](http://www.collectivites-locales.gouv.fr/liste-et-composition-2015)
-  pour les EPCI
-* [le COG de l’INSEE](https://www.insee.fr/fr/information/2666684)
-  pour les arrondissements
+- [les exports OpenStreetMap](http://osm13.openstreetmap.fr/~cquest/openfla/export/) pour les arrondissements, EPCI, départements, régions, communes et cantons
+- [les contours des IRIS issus de l’INSEE](https://www.data.gouv.fr/fr/datasets/contour-des-iris-insee-tout-en-un/)
+- [les contours des pays de TheMaticMapping](http://thematicmapping.org/downloads/) pour l’outre-mer
+- [la base officielle des code postaux de La Poste](https://www.data.gouv.fr/fr/datasets/base-officielle-des-codes-postaux/) pour les codes postaux
+- [la liste des EPCI](http://www.collectivites-locales.gouv.fr/liste-et-composition-2015) pour les EPCI
+- [le COG de l’INSEE](https://www.insee.fr/fr/information/2666684) pour les arrondissements
 
 Les arrondissements de Paris, Lyon et Marseille sont dynamiquement
 rattachés. Leurs populations sont agrégées dynamiquement.
@@ -36,3 +31,90 @@ d’outre-mer et communes.
 Les communes utilisent par exemple les exports OSM de 2017, 2016, 2015
 et 2013 ce qui permet d’avoir un historique des contours géographiques
 pour ces périodes. Il en va de même pour les régions en 2014 et 2016.
+
+## Démarrage
+
+Il y a plusieurs façon de mettre en place un environnement de dévelopment, nous en décrivons une.
+
+En partant du principe que vous avez Virtualenv et MongoDB d'installé sur votre poste:
+
+```bash
+$ git clone https://github.com/etalab/geozones.git
+$ cd geozones
+$ virtualenv -p /bin/python3 .
+$ source bin/activate
+$ pip install -r requirements.pip
+$ ./geozones.py
+```
+
+## Modèle
+
+Il y a deux modèles principaux:
+
+- les niveaux hierarchiques
+- les zones/territoires
+
+GeoZones utilise utilise MongoDB comme stockage de travail.
+
+### Niveaux
+
+Ils définissent la relation entre le code des niveaux et leurs noms.
+Ils ne sont pas stockées en base mais sont exportés avec les attributs suivants:
+
+| Attribut    | Description                                                                             |
+|-------------|-----------------------------------------------------------------------------------------|
+| id          | Un identifiant textuel (ex: `country`, `fr:commune`...)                                 |
+| label       | La representation textuelle humaine en anglais (ex: `World`). __\*__                    |
+| admin_level | Un indice d'échelle administrative (0 étant le plus grand niveaux et 100 le plus petit) |
+| parents     | La liste des identifiants des parents connus d'un niveau                                |
+
+__\*__: Les libellés sont optionnellement traductibles
+
+
+#### Niveaux communs
+
+
+| identifiant      | niveau | description                                                            |
+|------------------|--------|------------------------------------------------------------------------|
+| `country-group`  | 10     | Groupe de pays (`World`, `UE`...)                                      |
+| `contry`         | 20     | Un pays                                                                |
+| `country-subset` | 30     | Un sous-ensemble administratif d'un pays (ex: `France metropolitaine`) |
+
+
+#### Niveaux français
+
+| identifiant         | niveau | description                    |
+|---------------------|--------|--------------------------------|
+| `fr:region`         | 40     | Régions françaises             |
+| `fr:epci`           | 68     | EPCI                           |
+| `fr:departement`    | 60     | Départements français          |
+| `fr:collectivite`   | 60     | Collectivités d'outremer       |
+| `fr:arrondissement` | 70     | Arrondissements français       |
+| `fr:commune`        | 80     | Communes française             |
+| `fr:canton`         | 98     | Cantons français               |
+| `fr:iris`           | 98     | Iris INSEE                     |
+
+### Zones
+
+Une zone est un polygonal geospatial pour un niveau donnée. Il a au moins un code unique (sur son niveau uniquement) and un nom. Il peut avoir plusieurs clés connues, pas nécéssairement uniques (ex: le code postal peut être paratagé par plusieurs communes).
+
+Les libéllés sont optionnellement traductibles.
+
+Certaines zones sont définies comme étant l'aggrégation d'autres zones. Elles sont appelées _aggregation_ dans geozones et construite après que toutes les données ai été chargées.
+
+Les attributs suivants sont exportés dans le GeoJSON produit:
+
+| Attribut   | Description                                                     |
+|------------|-----------------------------------------------------------------|
+| id         | Un identifiant unique définit par `<code>:<code>[@<creation>]`  |
+| code       | L'identifiant unique de la zone sur ce niveau                   |
+| level      | L'identifiant du niveau                                         |
+| name       | Le nom d'affichage (peut être traductible)                      |
+| population | Population estimée/approximative _(optionnel)_                  |
+| area       | L'aire estimée/approximative en km² _(optionnel)_               |
+| wikipedia  | Une référence Wikipedia _(optionnel)_                           |
+| dbpedia    | Une référence DBPedia _(optionnel)_                             |
+| flag       | Une référence DBPedia à un drapeau _(optionnel)_                |
+| blazon     | Une référence DBPedia à un blason _(optionnel)_                 |
+| keys       | Un dictionnaire des clés connues pour cette zone                |
+| parents    | Une liste de tous les parents connus                            |

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-GeoZones
-========
+# GeoZones
 
 Simplistic spatial/administrative referential.
 
-*Pour une documentation relative aux niveaux administratifs français, veuillez consulter le fichier [LISEZMOI.md](LISEZMOI.md).*
+_Pour une documentation relative aux niveaux administratifs français, veuillez consulter le fichier [LISEZMOI.md](LISEZMOI.md)._
 
 This project is a set of tools to produce a shared spatial/administrative referential based on open datasets.
 
@@ -11,28 +10,26 @@ The purpose is to be embeddable in applications for autocompletion. There is no 
 
 These tools work on and exports _WGS84_ spatial data.
 
-Requirements
-------------
+## Requirements
 
 This project uses MongoDB 2.6+ and GDAL as main tooling. Build tools are written in Python 3 and make use of:
 
--   click
--   PyMongo
--   Fiona
--   Shapely
+- click
+- PyMongo
+- Fiona
+- Shapely
 
 The web interface requires Flask.
 
 Translations requires Babel and Transifex client.
 
-Getting started
----------------
+## Getting started
 
 There are many way of getting a development environment started.
 
 Assuming you have Virtualenv and MongoDB installed and configured on you computer:
 
-``` sourceCode
+```bash
 $ git clone https://github.com/etalab/geozones.git
 $ cd geozones
 $ virtualenv -p /bin/python3 .
@@ -41,13 +38,12 @@ $ pip install -r requirements.pip
 $ ./geozones.py
 ```
 
-Model
------
+## Model
 
 There are two main models:
 
--   level hierarchies
--   zone/territories
+- level hierarchies
+- zone/territories
 
 GeoZones use MongoDB as working storage.
 
@@ -79,7 +75,7 @@ Currently geozones support the following levels:
 | `country-subset` | 30                   | An administrative subset of a country
 
 
-#### France levels
+#### French levels
 
 | identifier          | administrative level | description                    |
 |---------------------|----------------------|--------------------------------|
@@ -102,31 +98,30 @@ Some zones are defined as an aggregation of other zones. They are called _aggreg
 
 The following properties are exported in the GeoJSON output:
 
-| Property   | Description                                      |
-|------------|--------------------------------------------------|
-| id         | A unique identifier defined by `<level>:<code>`  |
-| code       | The zone unique identifier in this level         |
-| level      | The level identifier                             |
-| name       | The zone display name (can be translatable)      |
-| population | Estimated/approximative population *(optional)*  |
-| area       | Estimated/approximative area in km2 *(optional)* |
-| wikipedia  | A Wikipedia reference *(optional)*               |
-| dbpedia    | A DBPedia reference *(optional)*                 |
-| flag       | A DBPedia reference to a flag *(optional)*       |
-| blazon     | A DBPedia reference to a blazon *(optional)*     |
-| keys       | A dictionary of known keys/code for this zone    |
-| parents    | A list of every known parent zone identifier     |
+| Property   | Description                                                 |
+|------------|-------------------------------------------------------------|
+| id         | A unique identifier defined by `<level>:<code>[@creation]`  |
+| code       | The zone unique identifier in this level                    |
+| level      | The level identifier                                        |
+| name       | The zone display name (can be translatable)                 |
+| population | Estimated/approximative population _(optional)_             |
+| area       | Estimated/approximative area in km² _(optional)_            |
+| wikipedia  | A Wikipedia reference _(optional)_                          |
+| dbpedia    | A DBPedia reference _(optional)_                            |
+| flag       | A DBPedia reference to a flag _(optional)_                  |
+| blazon     | A DBPedia reference to a blazon _(optional)_                |
+| keys       | A dictionary of known keys/code for this zone               |
+| parents    | A list of every known parent zone identifier                |
 
 > Note that you can choose via the keys option which properties you would like to export during the `dist`ribution step.
 
-Translations
-------------
+## Translations
 
 Level names and some territories are translatable. They are provided as _gettext_ files. Translations are handled on [transifex](https://www.transifex.com/projects/p/geozones/).
 
 Here’s the workflow:
 
-``` sourceCode
+```bash
 # Extract translatabls labels
 $ pybabel extract -F babel.cfg -o translations/geozones.pot .
 # Push updated translations template to Transifex
@@ -139,104 +134,90 @@ $
 
 To add an extra language:
 
-``` sourceCode
+```bash
 $ pybabel init -D geozones -i translations/geozones.pot -d translations -l <language code>
 $ tx push -t -l <language code>
 ```
 
-Commands
-========
+## Commands
 
 A set of commands are provided for the build process. You can list them all with:
 
-``` sourceCode
+```bash
 $ ./geozones.py --help
 ```
 
-`download`
-----------
+### `download`
 
 Download the required datasets. Datasets will be stored into a `downloads` subdirectory.
 
-`load`
-------
+### `load`
 
 Load and process datasets into database.
 
-`aggregate`
------------
+### `aggregate`
 
 Perform zones aggregations for zones defined as aggregation of others.
 
-`postprocess`
--------------
+### `postprocess`
 
 Perform some non geospatial processing (ex: set the postal codes, attach the parents…).
 
 `--exclude` and `--only` options make possible to run a set of postprocess function(s).
 
-`dist`
-------
+### `dist`
 
 Dump the produced dataset as GeoJSON files for distribution. Files are dumped in a _build_ subdirectory.
 
-`full`
-------
+### `full`
 
 All in one task equivalent to:
 
-``` sourceCode
+```bash
 # Perform all tasks from download to distibution
 $ ./geozones.py download load aggregate postprocess dist
 ```
 
-`explore`
----------
+### `explore`
 
 Serve a _web interface_ to explore the generated data.
 
-`status`
---------
+### `status`
 
 Display some useful informations and statistics.
 
 Commands are chainable so you can write:
 
-``` sourceCode
+```bash
 # Perform all tasks from download to distibution
 $ ./geozones.py download load -d aggregate postprocess dist dist -s status
 ```
 
-Options
-=======
+## Options
 
-`serialization`
----------------
+### `serialization`
 
 You can export data in (Geo)JSON or [msgpack](http://msgpack.org/) formats.
 
 The _msgpack_ format consumes more CPU on deserialization but does not take many gigabytes of RAM given that it can iterate over data without loading the whole file.
 
-Reused datasets
-===============
+## Reused datasets
 
--   [NaturalEarth administrative boundaries](http://www.naturalearthdata.com/downloads/110m-cultural-vectors/110m-admin-0-countries/)
--   [The Matic Mapping country boundaries](http://thematicmapping.org/downloads/world_borders.php)
--   [OpenStreetMap french regions boundaries](http://www.data.gouv.fr/datasets/contours-des-regions-francaises-sur-openstreetmap/)
--   [OpenStreetMap french counties boundaries](http://www.data.gouv.fr/datasets/contours-des-departements-francais-issus-d-openstreetmap/)
--   [OpenStreetMap french EPCIs boundaries](http://www.data.gouv.fr/datasets/contours-des-epci-2014/)
--   [OpenStreetMap french districts boundaries](http://www.data.gouv.fr/datasets/contours-des-arrondissements-francais-issus-d-openstreetmap/)
--   [OpenStreetMap french towns boundaries](http://www.data.gouv.fr/datasets/decoupage-administratif-communal-francais-issu-d-openstreetmap/)
--   [OpenStreetMap french cantons boundaries](http://www.data.gouv.fr/fr/datasets/contours-osm-des-cantons-electoraux-departementaux-2015/)
--   [IGN/ISEE IRIS aggregated version](https://www.data.gouv.fr/fr/datasets/contour-des-iris-insee-tout-en-un/)
--   [French postal codes database](https://www.data.gouv.fr/fr/datasets/base-officielle-des-codes-postaux/)
+- [NaturalEarth administrative boundaries](http://www.naturalearthdata.com/downloads/110m-cultural-vectors/110m-admin-0-countries/)
+- [The Matic Mapping country boundaries](http://thematicmapping.org/downloads/world_borders.php)
+- [OpenStreetMap french regions boundaries](http://www.data.gouv.fr/datasets/contours-des-regions-francaises-sur-openstreetmap/)
+- [OpenStreetMap french counties boundaries](http://www.data.gouv.fr/datasets/contours-des-departements-francais-issus-d-openstreetmap/)
+- [OpenStreetMap french EPCIs boundaries](http://www.data.gouv.fr/datasets/contours-des-epci-2014/)
+- [OpenStreetMap french districts boundaries](http://www.data.gouv.fr/datasets/contours-des-arrondissements-francais-issus-d-openstreetmap/)
+- [OpenStreetMap french towns boundaries](http://www.data.gouv.fr/datasets/decoupage-administratif-communal-francais-issu-d-openstreetmap/)
+- [OpenStreetMap french cantons boundaries](http://www.data.gouv.fr/fr/datasets/contours-osm-des-cantons-electoraux-departementaux-2015/)
+- [IGN/ISEE IRIS aggregated version](https://www.data.gouv.fr/fr/datasets/contour-des-iris-insee-tout-en-un/)
+- [French postal codes database](https://www.data.gouv.fr/fr/datasets/base-officielle-des-codes-postaux/)
 
 
-Possible improvements
-=====================
+## Possible improvements
 
-Build
------
+### Build
 
 - Incremental downloads, maybe with checksum check
 - Global post-processor
@@ -245,13 +226,11 @@ Build
 - Distribute GeoZone as a standalone python executable
 - Some quality check tools
 
-Fields
-------
+### Fields
 
 - Global weight = f(population, area, level)
 
-Output
-------
+### Output
 
 - Different precision output
 - Localized JSON outputs (Output are english only right now)
@@ -260,9 +239,8 @@ Output
 - Model versioning
 - Statistics/coverages in levels
 
-Web interface
--------------
+### Web interface
 
--   Querying
--   Only fetch zones for viewport (less intensive for lower layers)
--   A full web-service as a separate project
+- Querying
+- Only fetch zones for viewport (less intensive for lower layers)
+- A full web-service as a separate project

--- a/README.md
+++ b/README.md
@@ -53,7 +53,44 @@ GeoZones use MongoDB as working storage.
 
 ### Levels
 
-They define relationships between levels and their names. They are not stored into any database.
+They define relationships between levels and their names.
+They are not stored into the database but they are exported with the following properties:
+
+| Property    | Description                                                                 |
+|-------------|-----------------------------------------------------------------------------|
+| id          | A string identifier for the level (ie. `country`, `fr:commune`...)          |
+| label       | The humain string representation in English (ie. `World`). __\*__           |
+| admin_level | An administrative scale index (0 is the biggest and 100 the smallest level) |
+| parents     | The list of known parent levels identifier                                  |
+
+__\*__: Labels are optionally translatables
+
+
+You can contribute your country specific levels.
+Currently geozones support the following levels:
+
+#### Common levels
+
+
+| identifier       | administrative level | description
+|------------------|----------------------|--------------
+| `country-group`  | 10                   | Groups of countries (`World`, `UE`...)
+| `contry`         | 20                   | A country
+| `country-subset` | 30                   | An administrative subset of a country
+
+
+#### France levels
+
+| identifier          | administrative level | description                    |
+|---------------------|----------------------|--------------------------------|
+| `fr:region`         | 40                   | Regions of France              |
+| `fr:epci`           | 68                   | Intercommunality of France     |
+| `fr:departement`    | 60                   | Departements of France         |
+| `fr:collectivite`   | 60                   | French overseas collectivities |
+| `fr:arrondissement` | 70                   | Arrondissements of France      |
+| `fr:commune`        | 80                   | Communes of France             |
+| `fr:canton`         | 98                   | Cantons of France              |
+| `fr:iris`           | 98                   | Iris of France                 |
 
 ### Zones
 
@@ -65,20 +102,20 @@ Some zones are defined as an aggregation of other zones. They are called _aggreg
 
 The following properties are exported in the GeoJSON output:
 
-Property | Description
----------|------------
-id | A unique identifier defined by `<level>/<code>`
-code | The zone unique identifier in this level
-level | The level identifier
-name | The zone display name (can be translatable)
-population | Estimated/approximative population *(optional)*
-area | Estimated/approximative area in km2 *(optional)*
-wikipedia | A Wikipedia reference *(optional)*
-dbpedia | A DBPedia reference *(optional)*
-flag | A DBPedia reference to a flag *(optional)*
-blazon | A DBPedia reference to a blazon *(optional)*
-keys | A dictionary of known keys/code for this zone
-parents | A list of every known parent zone identifier
+| Property   | Description                                      |
+|------------|--------------------------------------------------|
+| id         | A unique identifier defined by `<level>:<code>`  |
+| code       | The zone unique identifier in this level         |
+| level      | The level identifier                             |
+| name       | The zone display name (can be translatable)      |
+| population | Estimated/approximative population *(optional)*  |
+| area       | Estimated/approximative area in km2 *(optional)* |
+| wikipedia  | A Wikipedia reference *(optional)*               |
+| dbpedia    | A DBPedia reference *(optional)*                 |
+| flag       | A DBPedia reference to a flag *(optional)*       |
+| blazon     | A DBPedia reference to a blazon *(optional)*     |
+| keys       | A dictionary of known keys/code for this zone    |
+| parents    | A list of every known parent zone identifier     |
 
 > Note that you can choose via the keys option which properties you would like to export during the `dist`ribution step.
 

--- a/france.py
+++ b/france.py
@@ -14,17 +14,17 @@ from geozones import DB
 _ = lambda s: s
 
 
-region = Level('fr:region', _('French region'), country)
-epci = Level('fr:epci', _('French intermunicipal (EPCI)'), region)
-departement = Level('fr:departement', _('French county'), region)
+region = Level('fr:region', _('French region'), 40, country)
+epci = Level('fr:epci', _('French intermunicipal (EPCI)'), 68, region)
+departement = Level('fr:departement', _('French county'), 60, region)
 collectivite = Level('fr:collectivite', _('French overseas collectivities'),
-                     region)
-district = Level('fr:arrondissement', _('French district'), departement)
-commune = Level('fr:commune', _('French town'), district, epci)
-canton = Level('fr:canton', _('French canton'), departement)
+                     60, region)
+district = Level('fr:arrondissement', _('French district'), 70, departement)
+commune = Level('fr:commune', _('French town'), 80, district, epci)
+canton = Level('fr:canton', _('French canton'), 98, departement)
 
 # Not opendata yet
-iris = Level('fr:iris', _('Iris (Insee districts)'), commune)
+iris = Level('fr:iris', _('Iris (Insee districts)'), 98, commune)
 
 # Cities with districts
 PARIS_DISTRICTS = [

--- a/geo.py
+++ b/geo.py
@@ -16,11 +16,12 @@ class Level(object):
     This class handle level declaration and processing.
     '''
 
-    def __init__(self, id, label, *parents):
+    def __init__(self, id, label, admin_level, *parents):
         # TODO: handle multiple parents
         self.id = id
         self.label = label
         self.parents = parents
+        self.admin_level = admin_level
         self.children = []
         self.extractors = []
         self.postprocessors = []
@@ -247,6 +248,6 @@ class Level(object):
 # Force translatables string extraction
 _ = lambda s: s  # noqa
 # Register first levels
-root = country_group = Level('country-group', _('Country group'))
-country = Level('country', _('Country'), country_group)
-country_subset = Level('country-subset', _('Country subset'), country)
+root = country_group = Level('country-group', _('Country group'), 10)
+country = Level('country', _('Country'), 20, country_group)
+country_subset = Level('country-subset', _('Country subset'), 30, country)

--- a/geozones.py
+++ b/geozones.py
@@ -258,6 +258,7 @@ def dist(ctx, pretty, split, compress, serialization, keys):
         data = [{
             'id': level.id,
             'label': level.label,
+            'admin_level': level.admin_level,
             'parents': [p.id for p in level.parents]
         } for level in ctx.obj['levels']]
         if serialization == 'json':


### PR DESCRIPTION
This pull request adds an administrative level field to level model (and export).

Name is taken from udata (see https://github.com/opendatateam/udata/blob/master/udata/core/spatial/commands.py#L57)
 Weight are imported values from https://github.com/opendatateam/udata/blob/master/udata/migrations/2017-01-05-geozones-admin-levels.js#L6-L8 and https://github.com/etalab/udata-gouvfr/blob/master/udata_gouvfr/migrations/2017-01-05-geozones-admin-levels-fr.js#L6-L12