### PR TITLE
Merged geologos as a geozones command

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,10 @@ This allows using an external download manager by example.
 mkdir download && cd download && geozones sourceslist | xargs -P 10 -n 1 curl -O
 ```
 
+### `logos`
+
+Fetch zones logos/flags/blazons from Wikipedia when available.
+
 ## Options
 
 ### `serialization`

--- a/geozones/__main__.py
+++ b/geozones/__main__.py
@@ -17,6 +17,7 @@ from .tools import (
     extract_meta_from_headers
 )
 from .model import root
+from .logos import fetch_logos, compress_logos
 from .france.histo import (
     load_communes, load_departements, load_collectivites, load_regions,
     URLS as GEOHISTO_URLS
@@ -321,6 +322,18 @@ def full(ctx, drop, pretty, split, compress, serialization, keys):
     ctx.invoke(postprocess)
     ctx.invoke(dist, pretty=pretty, split=split, compress=compress,
                serialization=serialization, keys=keys)
+
+
+@cli.command()
+@click.pass_context
+@click.option('-c/-nc', '--compress/--no-compress', default=False)
+def logos(ctx, compress):
+    '''Fetch logos from data'''
+    title(logos.__doc__)
+    zones = DB()
+    fetch_logos(zones, DL_DIR)
+    if compress:
+        compress_logos(DL_DIR, DIST_DIR)
 
 
 @cli.command()

--- a/geozones/logos.py
+++ b/geozones/logos.py
@@ -1,0 +1,63 @@
+import os
+import tarfile
+
+import requests
+
+from .tools import info, success
+
+DBPEDIA_MEDIA_URL = 'http://commons.wikimedia.org/wiki/Special:FilePath/'
+LOGOS_FOLDER_PATH = 'logos'
+LOGOS_FILENAME = 'geologos.tar.xz'
+
+# Define a user agent to follow https://www.mediawiki.org/wiki/API:Etiquette
+USER_AGENT = 'geozones/1.0 (https://github.com/etalab/geozones)'
+HEADERS = {'user-agent': USER_AGENT}
+
+
+def fetch_logos(zones, dl_dir):
+    """
+    Fetch logos (logos or flags or blazons) from `zones`.
+
+    Not optimized to avoid being blacklisted by wikimedia.
+    That command takes about 3h30 as of February 2016.
+
+    Existing files are not fetched but previous 404 are retried.
+    """
+    info('Fetching logos from Wikimedia')
+    path = os.path.join(dl_dir, LOGOS_FOLDER_PATH)
+    if not os.path.exists(path):
+        os.makedirs(path)
+    for zone in zones.find({'$or': [
+            {'flag': {'$exists':  True}},
+            {'blazon': {'$exists':  True}},
+            {'logo': {'$exists':  True}}
+            ]},
+            no_cursor_timeout=True):
+        filename = zone.get('flag', zone.get('blazon', zone.get('logo')))
+        if not filename:
+            continue
+        filepath = os.path.join(path, filename)
+        if os.path.exists(filepath):
+            continue
+        url = DBPEDIA_MEDIA_URL + filename
+        print('Fetching {url}'.format(url=url))
+        r = requests.get(url, stream=True, headers=HEADERS)
+        if r.status_code == 404:
+            continue
+        with open(filepath, 'wb') as file_destination:
+            for chunk in r.iter_content(chunk_size=1024):
+                file_destination.write(chunk)
+    success('Logos fetched')
+
+
+def compress_logos(dl_dir, dist_dir):
+    """Compress the `logos` folders into a unique archive file."""
+    filename = os.path.join(dist_dir, LOGOS_FILENAME)
+    path = os.path.join(dl_dir, LOGOS_FOLDER_PATH)
+    info('Compressing logos to {filename}', filename=filename)
+    with tarfile.open(filename, 'w:xz') as txz:
+        for (dirpath, dirnames, filenames) in os.walk(path):
+            for name in filenames:
+                txz.add(os.path.join(path, name))
+            break
+    success('Compressing done')


### PR DESCRIPTION
This PR merges [`geologos`](https://github.com/etalab/geologos) as a `geozones` command.
This introduce the `geozones logos` command allowing to keep logic in sync with the current state of geozone.

There are subtle changes:
- downloaded images and archive respect `DL_DIR` and `DIST_DIR`
- Define a user agent to follow https://www.mediawiki.org/wiki/API:Etiquette
- Handle the `logo` property in addition to `flag` and `blazon`
- Prevent timeout error while iterating over MongoDB cursor