### PR TITLE
Fixes for Natural Earth 3+

### DIFF
--- a/geozones/international.py
+++ b/geozones/international.py
@@ -1,10 +1,66 @@
 from .model import country, country_group
-from .tools import info, success
+from .tools import info, warning, success
 
 _ = lambda s: s  # noqa: E731
 
 
-@country.extractor('http://naciscdn.org/naturalearth/110m/cultural/ne_110m_admin_0_countries_lakes.zip')  # NOQA
+# This is the latest URL (currently 4.1.0)
+# There is no versionned adress right now
+NE_URL = 'https://www.naturalearthdata.com/http//www.naturalearthdata.com/download/110m/cultural/ne_110m_admin_0_countries_lakes.zip'
+
+# Natural Earth stores None as '-99'
+NE_NONE = '-99'
+
+# Associate some fixes to Natural Earth polygons.
+# Use the `NE_ID` attribute to identify each polygon
+NE_FIXES = {
+    # France is lacking ISO codes
+    1159320637: {
+        'ISO_A2': 'FR',
+        'ISO_A3': 'FRA',
+    },
+    # Norway is lacking ISO codes
+    1159321109: {
+        'ISO_A2': 'NO',
+        'ISO_A3': 'NOR',
+    }
+}
+
+
+def ne_prop(props, key, cast=str):
+    '''
+    Fetch a Natural Eartch property.
+
+    This method handle:
+    - both upper and lower case as casing has been changing between releases
+    - try with a trailing underscore (some properties are moving)
+    - returns `None` instead of `-99`
+    - match fixes if any
+    - perform a cast if necessary
+    - case lowering
+    '''
+    ne_id = props['NE_ID']
+    upper_key = key.upper()
+    keys = (upper_key, key.lower(), upper_key + '_', key.lower() + '_')
+    value = None
+    for key in keys:
+        if key in props:
+            value = props[key]
+            continue
+    if value == NE_NONE:  # None value for Natural Earth
+        if ne_id in NE_FIXES and upper_key in NE_FIXES[ne_id]:
+            value = NE_FIXES[ne_id][upper_key]
+        else:
+            return None
+    if not value:
+        return None
+    elif cast is str:
+        return value.lower()
+    else:
+        return cast(value)
+
+
+@country.extractor(NE_URL, encoding='utf-8')  # NOQA
 def extract_country(db, polygon):
     '''
     Extract a country information from single MultiPolygon.
@@ -14,17 +70,20 @@ def extract_country(db, polygon):
     The main unique code used is ISO2.
     '''
     props = polygon['properties']
-    code = props['ISO_A2'].lower()
+    code = ne_prop(props, 'ISO_A2')
+    if not code:
+        warning('Missing iso code 2 for {NAME}, skipping'.format(**props))
+        return
     return {
         'code': code,
         'name': props['NAME'],
-        'population': int(props['POP_EST']),
+        'population': ne_prop(props, 'POP_EST', int),
         'parents': ['country-group:world'],
         'keys': {
             'iso2': code,
-            'iso3': props['ISO_A3'].lower(),
-            'un': props['UN_A3'],
-            'fips': (props.get('FIPS_10', '') or '').lower() or None,
+            'iso3': ne_prop(props, 'ISO_A3'),
+            'un': ne_prop(props, 'UN_A3'),
+            'fips': ne_prop(props, 'FIPS_10'),
         }
     }
 
@@ -37,8 +96,8 @@ country_group.aggregate(
 # European union
 UE_COUNTRIES = (
     'at', 'be', 'bg', 'cy', 'hr', 'dk', 'ee', 'fi', 'gr', 'fr', 'es', 'de',
-    'hu', 'ie', 'it', 'lv', 'lt', 'lu', 'mt', 'nl', 'pl', 'pt', 'cz', 'ro',
-    'gb', 'sk', 'si', 'se'
+    'hu', 'ie', 'it', 'lv', 'lt', 'lu', 'mt', 'nl', 'no', 'pl', 'pt', 'cz',
+    'ro', 'gb', 'sk', 'si', 'se'
 )
 
 country_group.aggregate('ue', _('European Union'), [


### PR DESCRIPTION
This PR applies some fixes for changes introduced by Natural Earth 3+ (current version is `4.1.0`).

- Shapefile is now `unicode` encoded instead of `latin-1`
- Some ISO codes went missing (geozones contains local fixes)
- Keys are now upper cased
- Some keys have a trailing underscore (`FIPS_10` became `FIPS_10_`)

This PR fixes these cases and make the process more resilient on these changes
