### PR TITLE
Ensure zone with validity gets a temporal identifier when not provided

### DIFF
--- a/geozones/model.py
+++ b/geozones/model.py
@@ -182,6 +182,10 @@ class Level(object):
                     zone_id = zone.get('_id')
                     if not zone_id:
                         zone_id = ':'.join((self.id, zone['code']))
+                        if 'validity' in zone and zone['validity'].get('start'):
+                            start = zone['validity']['start']
+                            zone_id = '@'.join((zone_id, start))
+
                     zone.update(_id=zone_id, level=self.id)
                     db.find_one_and_replace(
                         {'_id': zone_id}, zone, upsert=True)


### PR DESCRIPTION
This PR fixes automatic zone id generation for zones having a temporal validity