### PR TITLE
Update Fiona's version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'Fiona==1.8.6',
+        'Fiona==1.8.13',
         'Flask==1.0.2',
         'Shapely==1.6.4.post2',
         'click==7.0',


### PR DESCRIPTION
This MR updates the Fiona package to its latest version.
Using the latest version prevents the following error when using the `geozones` cli :
```
Traceback (most recent call last):
  File "/home/al/projects/logement/geozones/py_env/bin/geozones", line 11, in <module>
    load_entry_point('geozones', 'console_scripts', 'geozones')()
  File "/home/al/projects/logement/geozones/py_env/lib/python3.8/site-packages/pkg_resources/__init__.py", line 489, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/home/al/projects/logement/geozones/py_env/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2793, in load_entry_point
    return ep.load()
  File "/home/al/projects/logement/geozones/py_env/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2411, in load
    return self.resolve()
  File "/home/al/projects/logement/geozones/py_env/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2417, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/home/al/projects/logement/geozones/geozones/__main__.py", line 14, in <module>
    from .model import root
  File "/home/al/projects/logement/geozones/geozones/model.py", line 7, in <module>
    from fiona.crs import to_string
  File "/home/al/projects/logement/geozones/py_env/lib/python3.8/site-packages/fiona/__init__.py", line 83, in <module>
    from fiona.collection import BytesCollection, Collection
  File "/home/al/projects/logement/geozones/py_env/lib/python3.8/site-packages/fiona/collection.py", line 9, in <module>
    from fiona.ogrext import Iterator, ItemsIterator, KeysIterator
ImportError: /home/al/projects/logement/geozones/py_env/lib/python3.8/site-packages/fiona/ogrext.cpython-38-x86_64-linux-gnu.so: undefined symbol: OSRFixup
```